### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Craft
-
+[![Run on Repl.it](https://repl.it/badge/github/fogleman/Craft)](https://repl.it/github/fogleman/Craft)
 Minecraft clone for Windows, Mac OS X and Linux. Just a few thousand lines of C using modern OpenGL (shaders). Online multiplayer support is included using a Python-based server.
 
 http://www.michaelfogleman.com/craft/


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@BraedenHermance/Craft-2).